### PR TITLE
feat(selenium-grid): Update index.ts against master branch - run webdriver-manager as a node for hub in Selenium grid mode

### DIFF
--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -79,6 +79,11 @@ const standaloneNodeOption: yargs.Options = {
   describe: 'Start the selenium server standalone with role set to "node".',
   type: 'boolean'
 };
+const GRID_NODE = 'grid_node';
+const standaloneNodeOption: yargs.Options = {
+  describe: 'Start the selenium grid server with role set to "node".',
+  type: 'boolean'
+};
 const VERSIONS_CHROME = 'versions.chrome';
 const versionsChromeOption: yargs.Options = {
   describe: 'The chromedriver version.',
@@ -132,6 +137,7 @@ yargs
               .option(OUT_DIR, outDirOption)
               .option(STANDALONE, standaloneOption)
               .option(STANDALONE_NODE, standaloneNodeOption)
+              .option(GRID_NODE, gridNodeOption)
               .option(VERSIONS_CHROME, versionsChromeOption)
               .option(VERSIONS_GECKO, versionsGeckoOption)
               .option(VERSIONS_IE, versionsIeOption)

--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -80,7 +80,7 @@ const standaloneNodeOption: yargs.Options = {
   type: 'boolean'
 };
 const GRID_NODE = 'grid_node';
-const standaloneNodeOption: yargs.Options = {
+const gridNodeOption: yargs.Options = {
   describe: 'Start the selenium grid server with role set to "node".',
   type: 'boolean'
 };


### PR DESCRIPTION
It is possible to run webdriver-manager as a node for hub in Selenium grid mode now.

$webdriver-manager start --runAsNodeForHub http://localhost:4444/grid/register