### PR TITLE
feat(selenium-grid): Update options.ts against master - run webdriver-manager as a node for hub in Selenium grid mode

### DIFF
--- a/lib/cmds/options.ts
+++ b/lib/cmds/options.ts
@@ -43,6 +43,8 @@ export interface Server {
   edge?: string;
   // Detach the server and return the process to the parent.
   runAsDetach?: boolean;
+  // Run as role = node option.
+  runAsGrid?: boolean;
   // Port number to start the server.
   port?: number;
 }

--- a/lib/cmds/options.ts
+++ b/lib/cmds/options.ts
@@ -43,8 +43,8 @@ export interface Server {
   edge?: string;
   // Detach the server and return the process to the parent.
   runAsDetach?: boolean;
-  // Run as role = node option.
-  runAsGrid?: boolean;
+  // Run as selenium grid = node option.
+  runAsGrid?: string;
   // Port number to start the server.
   port?: number;
 }

--- a/lib/cmds/options.ts
+++ b/lib/cmds/options.ts
@@ -44,7 +44,7 @@ export interface Server {
   // Detach the server and return the process to the parent.
   runAsDetach?: boolean;
   // Run as selenium grid = node option.
-  runAsGrid?: string;
+  runAsGrid?: boolean;
   // Port number to start the server.
   port?: number;
 }

--- a/lib/cmds/options.ts
+++ b/lib/cmds/options.ts
@@ -44,7 +44,7 @@ export interface Server {
   // Detach the server and return the process to the parent.
   runAsDetach?: boolean;
   // Run as selenium grid = node option.
-  runAsGrid?: boolean;
+  runAsGrid?: string;
   // Port number to start the server.
   port?: number;
 }


### PR DESCRIPTION
It is possible to run webdriver-manager as a node for hub in Selenium grid mode now.

$webdriver-manager start --runAsGrid http://localhost:4444/grid/register