### PR TITLE
feat(selenium-grid): Update utils.ts against master - run webdriver-manager as a node for hub in Selenium grid mode

### DIFF
--- a/lib/cmds/utils.ts
+++ b/lib/cmds/utils.ts
@@ -93,6 +93,7 @@ export function convertArgs2Options(argv: yargs.Arguments): Options {
     outDir: argv.out_dir as string,
     proxy: argv.proxy as string,
     githubToken: argv.github_token as string,
+    runAsGrid: argv.grid_node as string;
   };
 
   let versionsChrome, versionsGecko, versionsIe, versionsStandalone = undefined;
@@ -116,6 +117,7 @@ export function convertArgs2Options(argv: yargs.Arguments): Options {
     options.server = {};
     options.server.name = 'selenium';
     options.server.runAsNode = argv.standalone_node as boolean;
+    options.server.runAsGrid = argv.grid_node as string;
     options.server.runAsDetach = argv.detach as boolean;
     options.server.version = versionsStandalone;
     options.server.chromeLogs = argv.chrome_logs as string;


### PR DESCRIPTION
It is possible to run webdriver-manager as a node for hub in Selenium grid mode now.

$webdriver-manager start --runAsNodeForHub http://localhost:4444/grid/register